### PR TITLE
bug(#3): Add timeout for experiments

### DIFF
--- a/opendc-core/src/main/kotlin/nl/atlarge/opendc/platform/Experiment.kt
+++ b/opendc-core/src/main/kotlin/nl/atlarge/opendc/platform/Experiment.kt
@@ -25,6 +25,7 @@
 package nl.atlarge.opendc.platform
 
 import nl.atlarge.opendc.kernel.Kernel
+import nl.atlarge.opendc.kernel.time.Duration
 
 /**
  * A blueprint for a reproducible simulation in a pre-defined setting.
@@ -36,6 +37,16 @@ interface Experiment<out T> {
 	 * Run the experiment on the specified simulation [Kernel].
 	 *
 	 * @param kernel The simulation kernel to run the experiment.
+	 * @return The result of the experiment.
 	 */
 	fun run(kernel: Kernel): T
+
+	/**
+	 * Run the experiment on the specified simulation [Kernel].
+	 *
+	 * @param kernel The simulation kernel to run the experiment.
+	 * @param timeout The maximum duration of the experiment before returning to the caller.
+	 * @return The result of the experiment or `null`.
+	 */
+	fun run(kernel: Kernel, timeout: Duration): T?
 }

--- a/opendc-integration-jpa/core/src/main/kotlin/nl/atlarge/opendc/platform/JpaPlatformRunner.kt
+++ b/opendc-integration-jpa/core/src/main/kotlin/nl/atlarge/opendc/platform/JpaPlatformRunner.kt
@@ -45,6 +45,7 @@ fun main(args: Array<String>) {
 	properties["javax.persistence.jdbc.password"] = env["PERSISTENCE_PASSWORD"] ?: ""
 	val factory = Persistence.createEntityManagerFactory("opendc-simulator", properties)
 
+	val timeout = 10000L
 	val threads = 4
 	val executorService = Executors.newFixedThreadPool(threads)
 	val experiments = JpaExperimentManager(factory)
@@ -55,7 +56,7 @@ fun main(args: Array<String>) {
 		experiments.poll()?.let { experiment ->
 			logger.info { "Found experiment. Submitting for simulation now..." }
 			executorService.submit {
-				experiment.use { it.run(kernel) }
+				experiment.use { it.run(kernel, timeout) }
 			}
 		}
 


### PR DESCRIPTION
This change adds a timeout for experiments, which allows the user to set
an upper bound on the duration of an experiment.

I have set the default timeout to a duration of 10000 ticks, which should be enough for most experiments that will run.

Closes #3