### PR TITLE
bug(#4): Prevent scheduling to machines without processing units

### DIFF
--- a/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/platform/scheduler/FifoScheduler.kt
+++ b/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/platform/scheduler/FifoScheduler.kt
@@ -65,6 +65,7 @@ class FifoScheduler : Scheduler {
 		val iterator = queue.iterator()
 
 		machines
+			.filter { it.state.status != Machine.Status.HALT }
 			.forEach { machine ->
 				while (iterator.hasNext()) {
 					val task = iterator.next()

--- a/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/platform/scheduler/SrtfScheduler.kt
+++ b/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/platform/scheduler/SrtfScheduler.kt
@@ -62,6 +62,7 @@ class SrtfScheduler : Scheduler {
 		val iterator = tasks.sortedBy { it.remaining }.iterator()
 
 		machines
+			.filter { it.state.status != Machine.Status.HALT }
 			.forEach { machine ->
 				while (iterator.hasNext()) {
 					val task = iterator.next()

--- a/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/topology/container/Datacenter.kt
+++ b/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/topology/container/Datacenter.kt
@@ -30,7 +30,6 @@ import nl.atlarge.opendc.kernel.Context
 import nl.atlarge.opendc.kernel.Process
 import nl.atlarge.opendc.kernel.time.Duration
 import nl.atlarge.opendc.platform.scheduler.Scheduler
-import nl.atlarge.opendc.platform.workload.Job
 import nl.atlarge.opendc.platform.workload.Task
 import nl.atlarge.opendc.topology.Entity
 import nl.atlarge.opendc.topology.machine.Machine

--- a/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/topology/machine/Machine.kt
+++ b/opendc-stdlib/src/main/kotlin/nl/atlarge/opendc/topology/machine/Machine.kt
@@ -81,6 +81,12 @@ open class Machine : Entity<Machine.State>, Process<Machine> {
 		val cpus = outgoingEdges.destinations<Cpu>("cpu")
 		val speed = cpus.fold(0, { acc, cpu -> acc + cpu.clockRate * cpu.cores })
 
+		// Halt the machine if it has not processing units (see bug #4)
+		if (cpus.isEmpty()) {
+			update(State(Status.HALT))
+			return
+		}
+
 		var task: Task = receiveTask()
 		update(State(Status.RUNNING, task, load = 1.0, memory = state.memory + 50, temperature = 30.0))
 


### PR DESCRIPTION
This change prevents the currently available scheduler implementations
from scheduling tasks to machines without processing units, since these
machines cannot perform any work.

Closes #4