### PR TITLE
Interpolate machine state and task progress

### DIFF
--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/JpaBootstrap.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/JpaBootstrap.kt
@@ -41,7 +41,6 @@ class JpaBootstrap(val experiment: Experiment) : Bootstrap<JpaModel> {
         // Schedule all messages in the trace
         tasks.forEach { task ->
             if (task is Task) {
-                logger.info { "Scheduling $task" }
                 context.schedule(task, section.datacenter, delay = task.startTime)
             }
         }

--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/ExperimentState.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/ExperimentState.kt
@@ -50,4 +50,9 @@ enum class ExperimentState {
      * This state indicates the experiment has finished simulating.
      */
     FINISHED,
+
+    /**
+     * This states indicates the experiment was aborted due to a timeout.
+     */
+    ABORTED,
 }

--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/TaskState.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/TaskState.kt
@@ -25,7 +25,13 @@
 package com.atlarge.opendc.model.odc.integration.jpa.schema
 
 import com.atlarge.opendc.simulator.Instant
+import com.atlarge.opendc.simulator.instrumentation.interpolate
+import com.atlarge.opendc.simulator.instrumentation.lerp
+import kotlinx.coroutines.experimental.Unconfined
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.channels.consume
 import javax.persistence.Entity
+import kotlin.coroutines.experimental.CoroutineContext
 
 /**
  * The state of a [Task].
@@ -47,3 +53,22 @@ data class TaskState(
     val remaining: Int,
     val cores: Int
 )
+
+/**
+ * Linearly interpolate [n] amount of elements between every two occurrences of task progress measurements represented
+ * as [TaskState] instances passing through the channel.
+ *
+ * The operation is _intermediate_ and _stateless_.
+ * This function [consumes][consume] all elements of the original [ReceiveChannel].
+ *
+ * @param context The context of the coroutine.
+ * @param n The amount of elements to interpolate between the actual elements in the channel.
+ */
+fun ReceiveChannel<TaskState>.interpolate(n: Int, context: CoroutineContext = Unconfined): ReceiveChannel<TaskState> =
+    interpolate(n, context) { f, a, b ->
+        a.copy(
+            id = 0,
+            time = lerp(a.time, b.time, f),
+            remaining = lerp(a.remaining, b.remaining, f)
+        )
+    }

--- a/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Helpers.kt
+++ b/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Helpers.kt
@@ -1,0 +1,48 @@
+package com.atlarge.opendc.simulator.instrumentation
+
+import kotlinx.coroutines.experimental.Unconfined
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.channels.consumeEach
+import kotlinx.coroutines.experimental.channels.produce
+import kotlinx.coroutines.experimental.channels.toChannel
+import kotlinx.coroutines.experimental.launch
+import kotlin.coroutines.experimental.CoroutineContext
+
+/**
+ * Transform each element in the channel into a [ReceiveChannel] of output elements that is then flattened into the
+ * output stream by emitting elements from the channels as they become available.
+ *
+ * @param context The [CoroutineContext] to run the operation in.
+ * @param transform The function to transform the elements into channels.
+ * @return The flattened [ReceiveChannel] of merged elements.
+ */
+fun <E, R> ReceiveChannel<E>.flatMapMerge(context: CoroutineContext = Unconfined,
+                                          transform: suspend (E) -> ReceiveChannel<R>): ReceiveChannel<R> =
+    produce(context) {
+        val job = launch(Unconfined) {
+            consumeEach {
+                launch(coroutineContext) {
+                    transform(it).toChannel(this@produce)
+                }
+            }
+        }
+        job.join()
+    }
+
+/**
+ * Merge this channel with the other channel into an output stream by emitting elements from the channels as they
+ * become available.
+ *
+ * @param context The [CoroutineContext] to run the operation in.
+ * @param other The other channel to merge with.
+ * @return The [ReceiveChannel] of merged elements.
+ */
+fun <E, E1: E, E2: E> ReceiveChannel<E1>.merge(context: CoroutineContext = Unconfined,
+                                               other: ReceiveChannel<E2>): ReceiveChannel<E> =
+    produce(context) {
+        val job = launch(Unconfined) {
+            launch(coroutineContext) { toChannel(this@produce) }
+            launch(coroutineContext) { other.toChannel(this@produce) }
+        }
+        job.join()
+    }

--- a/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Interpolation.kt
+++ b/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Interpolation.kt
@@ -41,8 +41,15 @@ import kotlin.coroutines.experimental.CoroutineContext
  * @param interpolator A function to interpolate between the two element occurrences.
  */
 fun <E> ReceiveChannel<E>.interpolate(n: Int, context: CoroutineContext = Unconfined,
-                                      interpolator: (Double, E, E) -> E): ReceiveChannel<E> =
-    produce(context) {
+                                      interpolator: (Double, E, E) -> E): ReceiveChannel<E> {
+    require(n >= 0) { "The amount to interpolate must be non-negative" }
+
+    // If we do not want to interpolate any elements, just return the original channel
+    if (n == 0) {
+        return this
+    }
+
+    return produce(context) {
         consume {
             val iterator = iterator()
 
@@ -62,6 +69,7 @@ fun <E> ReceiveChannel<E>.interpolate(n: Int, context: CoroutineContext = Unconf
             }
         }
     }
+}
 
 /**
  * Perform a linear interpolation on the given double values.


### PR DESCRIPTION
This pull request implements interpolation of task progress (represented as the `TaskState` class) via the Interpolation helpers implemented in #20. The model assumes that tasks progress linearly between two measurements (since the time between measurements is usually small).

Implements #5 