### PR TITLE
refactor: Use top-level coroutineContext

### DIFF
--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/platform/JpaExperiment.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/platform/JpaExperiment.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.experimental.runBlocking
 import mu.KotlinLogging
 import java.io.Closeable
 import javax.persistence.EntityManager
+import kotlin.coroutines.experimental.coroutineContext
 import kotlin.system.measureTimeMillis
 import com.atlarge.opendc.model.odc.integration.jpa.schema.Experiment as InternalExperiment
 import com.atlarge.opendc.model.odc.integration.jpa.schema.Task as InternalTask

--- a/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Helpers.kt
+++ b/opendc-stdlib/src/main/kotlin/com/atlarge/opendc/simulator/instrumentation/Helpers.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.experimental.channels.produce
 import kotlinx.coroutines.experimental.channels.toChannel
 import kotlinx.coroutines.experimental.launch
 import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.coroutineContext
 
 /**
  * Transform each element in the channel into a [ReceiveChannel] of output elements that is then flattened into the


### PR DESCRIPTION
This change refactors the calls to the recently deprecated
`CoroutineScope.coroutineContext` to use top-level `coroutineContext`
property instead.

This deprecation is the result of moving to the latest version of the
`koltinx-coroutines` library. See
https://github.com/Kotlin/kotlinx.coroutines/blob/master/CHANGES.md for
more information.