### PR TITLE
refactor: Improve exception handling in processes

### DIFF
--- a/opendc-core/src/main/kotlin/com/atlarge/opendc/simulator/kernel/Simulation.kt
+++ b/opendc-core/src/main/kotlin/com/atlarge/opendc/simulator/kernel/Simulation.kt
@@ -63,18 +63,24 @@ interface Simulation<M> {
     /**
      * Step through one cycle in the simulation. This method will process all events in a single tick, update the
      * internal clock and then return the control to the user.
+     *
+     * This method will throw if a process running during the cycle throws an exception.
      */
     fun step()
 
     /**
      * Run a simulation over the specified model.
      * This method will step through multiple cycles in the simulation until no more message exist in the queue.
+     *
+     * This method will throw if a process running during a cycle throws an exception.
      */
     fun run()
 
     /**
      * Run a simulation over the specified model, stepping through cycles until the specified clock tick has
      * occurred. The control is then handed back to the user.
+     *
+     * This method will throw if a process running during a cycle throws an exception.
      *
      * @param until The point in simulation time at which the simulation should be paused and the control is handed
      * 				back to the user.

--- a/opendc-kernel-omega/src/main/kotlin/com/atlarge/opendc/omega/OmegaSimulation.kt
+++ b/opendc-kernel-omega/src/main/kotlin/com/atlarge/opendc/omega/OmegaSimulation.kt
@@ -430,11 +430,6 @@ internal class OmegaSimulation<M>(bootstrap: Bootstrap<M>) : Simulation<M>, Boot
          *
          * @param exception The exception to resume with.
          */
-        override fun resumeWithException(exception: Throwable) {
-            // Deregister process from registry in order to have the GC collect this context:w
-            registry.remove(process)
-
-            logger.error(exception) { "An exception occurred during the execution of a process" }
-        }
+        override fun resumeWithException(exception: Throwable) = throw exception
     }
 }

--- a/opendc-kernel-omega/src/test/kotlin/com/atlarge/opendc/omega/SmokeTest.kt
+++ b/opendc-kernel-omega/src/test/kotlin/com/atlarge/opendc/omega/SmokeTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.consumeEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * This test suite checks for smoke when running a large amount of simulations.
@@ -98,7 +99,7 @@ internal class SmokeTest {
     object CrashProcess : Process<Unit, Unit> {
         override val initialState = Unit
         override suspend fun Context<Unit, Unit>.run() {
-            TODO("This process should crash")
+            throw RuntimeException("This process should crash")
         }
     }
 
@@ -116,7 +117,7 @@ internal class SmokeTest {
         }
 
         val simulation = OmegaKernel.create(bootstrap)
-        simulation.run()
+        assertThrows<RuntimeException> {  simulation.run() }
     }
 
     class ModelProcess(private val value: Int) : Process<Boolean, Int> {


### PR DESCRIPTION
This pull request will improve exception handling of processes. 

At the moment, when a process throws an uncaught exception, the kernel will catch and log the exception, stop the offending process and then continue. This approach however might cause the user to overlook possible exceptions in processes and does not give any ability to the user for handling these exception.

This pull request changes the kernel implementation and specification such that the `step()` method  (and consequently `run()`) must propagate uncaught exceptions that occur in processes. This allows the caller to control the way exceptions are handled.