### PR TITLE
bug: Fix Hibernate detached entity error

### DIFF
--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/MachineState.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/MachineState.kt
@@ -56,7 +56,7 @@ data class MachineState(
          */
         val Interpolator: (Double, MachineState, MachineState) -> MachineState = { f, a, b ->
             a.copy(
-                id = 0,
+                id = null,
                 time = lerp(a.time, b.time, f),
                 temperature = lerp(a.temperature, b.temperature, f),
                 memoryUsage = lerp(a.memoryUsage, b.memoryUsage, f),

--- a/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/TaskState.kt
+++ b/opendc-model-odc/jpa/src/main/kotlin/com/atlarge/opendc/model/odc/integration/jpa/schema/TaskState.kt
@@ -54,7 +54,7 @@ data class TaskState(
          */
         val Interpolator: (Double, TaskState, TaskState) -> TaskState = { f, a, b ->
             a.copy(
-                id = 0,
+                id = null,
                 time = lerp(a.time, b.time, f),
                 remaining = lerp(a.remaining, b.remaining, f)
             )


### PR DESCRIPTION
This change fixes an exception that occurs when Hibernate tries to persist deatached `MachineState` and `TaskState` objects that are interpolated and with an incorrect id. Due to this bug, simulations that enable collection of machine and task states will fail.