### PR TITLE
chore: Use Jacoco 0.8.2 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
         kotlinx_coroutines_version = '0.23.4'
         junit_jupiter_version = '5.2.0'
         junit_platform_version = '1.2.0'
-        jacoco_version = '0.8.2-SNAPSHOT'
+        jacoco_version = '0.8.2'
     }
 }
 

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -63,13 +63,7 @@ test {
 }
 
 /* Coverage */
-repositories {
-    // This repository is needed to get the latest snapshot of Jacoco
-    maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
-}
-
 jacoco {
-    // We use the latest snapshot of Jacoco in order to get it to ignore Kotlin-generated code
     toolVersion = jacoco_version
 }
 


### PR DESCRIPTION
This change changes the build configuration to use the 0.8.2 release of
Jacoco that includes support for Kotlin. Previously, we were using the
0.8.2 snapshot version, but this is not available anymore, causing the
build to fail.