### PR TITLE
bug: Fix task dependents column handling via JPA

### DIFF
--- a/opendc-model-odc/jpa/src/main/resources/jpa/schema.xml
+++ b/opendc-model-odc/jpa/src/main/resources/jpa/schema.xml
@@ -192,15 +192,7 @@
                     <cascade-persist/>
                 </cascade>
             </many-to-many>
-            <many-to-many name="dependents" target-entity="Task">
-                <join-table name="task_dependencies">
-                    <join-column name="first_task_id"/>
-                    <inverse-join-column name="second_task_id"/>
-                </join-table>
-                <cascade>
-                    <cascade-persist/>
-                </cascade>
-            </many-to-many>
+            <many-to-many name="dependents" target-entity="Task" mapped-by="dependencies" />
 
             <basic name="inputSize"/>
             <basic name="outputSize"/>


### PR DESCRIPTION
This change fixes an issue where adding items to the dependents field
causes primary key violations due to incorrect JPA configuration.